### PR TITLE
Emergency hotfix!

### DIFF
--- a/etherpadlite/models.py
+++ b/etherpadlite/models.py
@@ -66,7 +66,8 @@ class PadGroup(models.Model):
         return result
 
     def save(self, *args, **kwargs):
-        self.EtherMap()
+        if not self.id:
+            self.EtherMap()
         super(PadGroup, self).save(*args, **kwargs)
 
     def Destroy(self):


### PR DESCRIPTION
In the save method of a group, we call the "createGroupIfNotExists"
method. The attributes for this method containing a randomized value,
so every time a group is changed (new users, moderators, ...) it gets
a new ID. That leads to clearing all pads of this group!
